### PR TITLE
Fix the definition of totalDigits to be less than or equals

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
           url:        "http://cristal.univ-lille.fr/~boneva/",
           company:    "University of Lille",
           companyURL: "http://www.univ-lille1.fr/" },
-        { name:       "Jose Labra Gayo",
+        { name:       "Jose Emilio Labra Gayo",
           url:        "http://di002.edv.uniovi.es/~labra/",
           company:    "University of Oviedo",
           companyURL: "http://www.uniovi.es/" },
@@ -925,7 +925,7 @@ _:User2
           <li id="nodeSatisfies-minexclusive">for "<code>minexclusive</code>" constraints, <span class="math">v &lt; num</span>,</li>
           <li id="nodeSatisfies-maxinclusive">for "<code>maxinclusive</code>" constraints, <span class="math">v &gt;= num</span>,</li>
           <li id="nodeSatisfies-maxexclusive">for "<code>maxexclusive</code>" constraints, <span class="math">v &gt; num</span>,</li>
-          <li id="nodeSatisfies-totaldigits">for "<code>totaldigits</code>" constraints, <span class="math">v</span> equals the number of digits in the <a data-cite="xmlschema-2#dt-canonical-representation">XML Schema canonical form</a>[[!xmlschema-2]] of the value of <span class="math">n</span>,</li>
+          <li id="nodeSatisfies-totaldigits">for "<code>totaldigits</code>" constraints, <span class="math">v</span> is less than or equals the number of digits in the <a data-cite="xmlschema-2#dt-canonical-representation">XML Schema canonical form</a>[[!xmlschema-2]] of the value of <span class="math">n</span>,</li>
           <li id="nodeSatisfies-fractiondigits">for "<code>fractiondigits</code>" constraints, <span class="math">v</span> is less than or equals the number of digits to the right of the decimal place in the <a data-cite="xmlschema-2#dt-canonical-representation">XML Schema canonical form</a>[[!xmlschema-2]] of the value of <span class="math">n</span>, ignoring trailing zeros.</li>
         </ul>
         <p>


### PR DESCRIPTION
The definition of `totalDigits` says that the number of digits must be equal. 

However, the original definition of `totalDigits` in XML Schema says that it must be _less than or equals_. 

I think it was just a typo in the definition of `totalDigits` because the definition of `fractionDigits` is right as _less than or equals_