### PR TITLE
Fix ShExC terminal rule 77 for PN_LOCAL

### DIFF
--- a/index.html
+++ b/index.html
@@ -5088,7 +5088,7 @@ otherwise the result is the left <a class="grammarRef" href="#prod-unaryTripleEx
 <td id="term-PN_LOCAL">[<span class="prodNo">77</span>]   </td>
 <td>&lt;<code class="production term">PN_LOCAL</code>&gt;</td>
 <td>   ::=   </td>
-<td><code class="content">(<span class="prod"><a class="grammarRef" href="#term-PN_CHARS_U">PN_CHARS_U</a></span> | ":" | [0-9] | <span class="prod"><a class="grammarRef" href="#term-PLX">PLX</a></span>) (<span class="prod"><a class="grammarRef" href="#term-PN_CHARS">PN_CHARS</a></span> | "." | ":" | <span class="prod"><a class="grammarRef" href="#term-PLX">PLX</a></span>)* </code></td>
+<td><code class="content">(<span class="prod"><a class="grammarRef" href="#term-PN_CHARS_U">PN_CHARS_U</a></span> | ":" | [0-9] | <span class="prod"><a class="grammarRef" href="#term-PLX">PLX</a></span>) ((<span class="prod"><a class="grammarRef" href="#term-PN_CHARS">PN_CHARS</a></span> | "." | ":" | <span class="prod"><a class="grammarRef" href="#term-PLX">PLX</a></span>)* (<span class="prod"><a class="grammarRef" href="#term-PN_CHARS">PN_CHARS</a></span> | ":" | <span class="prod"><a class="grammarRef" href="#term-PLX">PLX</a></span>))? </code></td>
 </tr>
 </tbody>
 


### PR DESCRIPTION
I've noticed that the `(PN_CHARS | ":" | PLX)` part ending a `PN_LOCAL` was missing in comparison to the definitions of this token in SPARQL and Turtle. The grammars from the https://github.com/shexSpec/grammar repo include this part too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcelotto/spec/pull/32.html" title="Last updated on Apr 28, 2019, 7:32 PM UTC (df3e399)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/shexSpec/spec/32/a813a21...marcelotto:df3e399.html" title="Last updated on Apr 28, 2019, 7:32 PM UTC (df3e399)">Diff</a>