### PR TITLE
Fix typo s/negiation/negation

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@ _:User2
       <div class="note">
 	<p>
 	  The schema <span class="math">Sch</span> might have several different stratifications but <code class="function">completeTyping(<span class="math">G</span>, <span class="math">Sch</span>)</code> is the same for all these stratifications.
-	  This property is reminiscent of the use of stratified negiation in Datalog.	  
+	  This property is reminiscent of the use of stratified negation in Datalog.	  
 	</p>
 	<p>
 	  In order to decide isValid(Sch, G, m), it is sufficient to compute only a portion of completeTyping using an appropriate algorithm.


### PR DESCRIPTION
Fix typo replacing negiation by negation


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 5, 2020, 7:08 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Flabra%2Fspec%2F901449cb114327193db82e87c931683610b4bd26%2Findex.html%3FisPreview%3Dtrue)

```
Navigation timeout of 30000 ms exceeded
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20shexSpec/spec%2334.)._
</details>
