### PR TITLE
fix ShExC exclusion bug in 2.1 (currently published) branch

### DIFF
--- a/index.html
+++ b/index.html
@@ -4572,7 +4572,28 @@ otherwise the result is the left <a class="grammarRef" href="#prod-unaryTripleEx
 <td id="prod-exclusion">[<span class="prodNo">50</span>]   </td>
 <td><code class="production prod">exclusion</code></td>
 <td>   ::=   </td>
-<td><code class="content">'.' '-' (<span class="prod"><a class="grammarRef" href="#prod-iri">iri</a></span> | <span class="prod"><a class="grammarRef" href="#prod-literal">literal</a></span> | <span class="prod"><a class="grammarRef" href="#term-LANGTAG">LANGTAG</a></span>) '~'?</code></td>
+<td><code class="content">'.' (<span class="prod"><a class="grammarRef" href="#prod-iriExclusion">iriExclusion</a></span> | <span class="prod"><a class="grammarRef" href="#prod-literalExclusion">literalExclusion</a></span> | <span class="prod"><a class="grammarRef" href="#prod-languageExclusion">languageExclusion</a></span>) +</code></td>
+</tr>
+
+<tr style="vertical-align: baseline">
+<td id="prod-iriExclusion">[<span class="prodNo">50.1</span>]   </td>
+<td><code class="production prod">iriExclusion</code></td>
+<td>   ::=   </td>
+<td><code class="content">'-' <span class="prod"><a class="grammarRef" href="#prod-iri">iri</a></span> '~'?</code></td>
+</tr>
+
+<tr style="vertical-align: baseline">
+<td id="prod-literalExclusion">[<span class="prodNo">50.2</span>]   </td>
+<td><code class="production prod">literalExclusion</code></td>
+<td>   ::=   </td>
+<td><code class="content">'-' <span class="prod"><a class="grammarRef" href="#prod-literal">literal</a></span> '~'?</code></td>
+</tr>
+
+<tr style="vertical-align: baseline">
+<td id="prod-languageExclusion">[<span class="prodNo">50.3</span>]   </td>
+<td><code class="production prod">languageExclusion</code></td>
+<td>   ::=   </td>
+<td><code class="content">'-' <span class="prod"><a class="grammarRef" href="#term-LANGTAG">LANGTAG</a></span> '~'?</code></td>
 </tr>
 
 <tr style="vertical-align: baseline">


### PR DESCRIPTION
still needs renumbering

```
[50]   	exclusion	   ::=  '.' (iriExclusion | literalExclusion | languageExclusion) +
[50.1]  iriExclusion	   ::=  '-' iri '~'?
[50.2]  literalExclusion   ::=  '-' literal '~'?
[50.3]  languageExclusion  ::=  '-' LANGTAG '~'?
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shexSpec/spec/pull/59.html" title="Last updated on Nov 28, 2023, 12:19 PM UTC (d1d5e1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/shexSpec/spec/59/8343717...d1d5e1b.html" title="Last updated on Nov 28, 2023, 12:19 PM UTC (d1d5e1b)">Diff</a>