### PR TITLE
Remove sx:negated from ShExR

### DIFF
--- a/ShExR.shex
+++ b/ShExR.shex
@@ -153,7 +153,6 @@ start=@<#Schema>
 <#TripleConstraint> CLOSED {
   a [sx:TripleConstraint] ;
   sx:inverse [true false] ? ;
-  sx:negated [true false] ? ;
   sx:min xsd:integer ? ;
   sx:max xsd:integer ? ;
   sx:predicate IRI ;


### PR DESCRIPTION
`ShExR.shex` here is a copy of [shexTest's `doc/ShExR.shex`](https://github.com/shexSpec/shexTest/blob/main/doc/ShExR.shex), and it still carries `sx:negated`.

`negated` was the ShEx 2.0 draft's `!` operator on TripleConstraint. It was removed from the language in November 2016 — shexTest `224c610` "- negated", and `d3f882d` "- negation" in this repo, which stripped the `negated:BOOL?` slot from the TripleConstraint production along with the `senseFlags` prose and the `"negated": true` examples — over the semantics problem in shexSpec/shex#11, and replaced by `{0,0}` cardinality and `ShapeNot`.

Seven weeks later, shexTest `fe51e15` ("~ aligned with ShExJ.jsg") copied it back into `ShExR.shex` from `doc/ShExJ.jsg`, which had not been cleaned up yet. `e01f012` ("`TripleConstraint -= negated:BOOL`") finally dropped it from the grammar in 2020 but left ShExR alone, so the RDF rendering kept a term the JSON rendering had just deleted.

It has never been in `http://www.w3.org/ns/shex`, is not in this spec's abstract syntax, and the ShExC parser has no `!` rule — so nothing can produce it and nothing consumes it. No test fixture anywhere carries a `shex:negated` triple.

Matches shexTest [#73](https://github.com/shexSpec/shexTest/pull/73) (which also removes it from `ShExR.{ttl,json,ntriples}`, `doc/ShExV.jsg` and a dangling `schemas/meta.ttl` reference) and shex.js `489a1a75`. `ShExR.shex` still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 6, 2026, 6:34 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/publications/spec-generator/) - Spec Generator is the web service used to build bikeshed/ReSpec specs

:link: [Related URL](https://www.w3.org/publications/spec-generator/?type=respec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2FshexSpec%2Fspec%2F8dc9d67b4a748347b10a61385ed91eec1cab36df%2Findex.html%3FisPreview%3Dtrue)

**Error output:**

```
Waiting failed: 30000ms exceeded
```

_This seems to be an issue with the [Spec Generator](https://www.w3.org/publications/spec-generator/) service. PR Preview doesn't manage this service and so has no control over it. If you've identified an issue with it, you can [report the issue to the maintainers of Spec Generator](https://github.com/w3c/spec-generator/issues/new) directly. Please be courteous. Thank you!_

_If you don't have enough information above to solve the error by yourself or if the issue doesn't seem related to Spec Generator, you can [file an issue with PR Preview](https://github.com/tobie/pr-preview/issues/new?title=Unidentified%20Error&body=See%20shexSpec/spec%2388.)._

</details>
